### PR TITLE
Paths

### DIFF
--- a/backend/fortran/conv_gmsh.f
+++ b/backend/fortran/conv_gmsh.f
@@ -10,8 +10,8 @@ c
 c
       integer i_sym
       integer gmsh_version
-      character file0_mesh*100, geoname*100
-      character file1_mesh*100, file2_mesh*100
+      character file0_mesh*500, geoname*500
+      character file1_mesh*500, file2_mesh*500
       integer i_mesh(3)
       integer max_ne, max_npt, i_err
       parameter(max_npt=250000, max_ne=120000)
@@ -33,8 +33,8 @@ c
       integer debug, ui, namelength2
       double precision time1, time2
       character objet*5
-      character file_ui*100
-      character*230 com_line
+      character file_ui*500
+      character*2000 com_line
 C
 Cf2py intent(in) geoname
 c
@@ -45,17 +45,23 @@ c
       gmsh_version = 2
 
       namelength2 = len_trim(geoname)
-      if (namelength2 .ge. 100) then
+      if (namelength2 .ge. 500) then
         write(*,*) "Name of .geo file is too long extend in ",
-     *  "conv_gmsh_py.f"
+     *  "conv_gmsh.f"
       endif
 C
-      file0_mesh = geoname(1:namelength2)//".geo"
-      file1_mesh = geoname(1:namelength2)//".msh"
-      file2_mesh = geoname(1:namelength2)//".mail"
-      file_ui    = geoname(1:namelength2)//".log"
+
+C      file0_mesh = geoname(1:namelength2)//".geo"
+C      file1_mesh = geoname(1:namelength2)//".msh"
+C      file2_mesh = geoname(1:namelength2)//".mail"
+C      file_ui    = geoname(1:namelength2)//".log"
+
+      file0_mesh = trim(geoname)//".geo"
+      file1_mesh = trim(geoname)//".msh"
+      file2_mesh = trim(geoname)//".mail"
+      file_ui    = trim(geoname)//".log"
 C
-      com_line = "gmsh -0 -2  -order 2 -v 0 -o " // 
+      com_line = "gmsh -0 -2  -order 2 -v 0 -o " //
      *    file1_mesh // " " // file0_mesh
 C
       call system(com_line)
@@ -93,7 +99,7 @@ c
 c
       if(max_npt .lt. npt) then
         open (unit=ui,file=file_ui)
-        write(*,*) 'CONV_GMSH: ATTENTION: max_npt < npt', 
+        write(*,*) 'CONV_GMSH: ATTENTION: max_npt < npt',
      *              max_npt, npt
         i_err = -1
         close(ui)
@@ -158,7 +164,7 @@ c
       do i=1,ne
         if(elm_type(i) .eq. gmsh_type_line) then
           ne_d1 = ne_d1 + 1
-          read(25,*) (etc_1(k), k=1,number_tags), 
+          read(25,*) (etc_1(k), k=1,number_tags),
      *      (nu_d1(k,ne_d1), k=1,3)
           do k=1,3
             j = nu_d1(k,ne_d1)
@@ -167,7 +173,7 @@ c
           typ_el_d1(ne_d1) = etc_1(physic_tag)
         elseif(elm_type(i) .eq. gmsh_type_el) then
           ne_d2 = ne_d2 + 1
-          read(25,*) (etc_1(k), k=1,number_tags), 
+          read(25,*) (etc_1(k), k=1,number_tags),
      *      (nu_d2(k,ne_d2), k=1,6)
           do k=1,6
             j = nu_d2(k,ne_d2)
@@ -208,8 +214,8 @@ c
 c      print*, 'Appel de renumerote'
 c
       if(i_sym .ne. 0) then
-        call symmetry(npt, ne_d2, 
-     *      max_ne, max_npt, idfn, nu_d2, typ_el_d2, 
+        call symmetry(npt, ne_d2,
+     *      max_ne, max_npt, idfn, nu_d2, typ_el_d2,
      *      x, y, i_sym)
       endif
 c

--- a/backend/fortran/geometry.f
+++ b/backend/fortran/geometry.f
@@ -6,7 +6,7 @@ c   type_nod != 0 => boundary point
 c
 c
       subroutine geometry (nel, npt, nnodes, nb_typ_el,
-     *    lx, ly, type_nod, type_el, table_nod, x, 
+     *    lx, ly, type_nod, type_el, table_nod, x,
      *    mesh_file)
 c
       implicit none
@@ -52,7 +52,7 @@ c     Connectivity table
         if(j .lt. 0) then
           write(ui,*)
           write(ui,*) "   ???"
-          write(ui,*) "geometry: type_el(i) < 0 : ", 
+          write(ui,*) "geometry: type_el(i) < 0 : ",
      *    i, type_el(i)
           write(ui,*) "geometry: Aborting..."
           stop
@@ -63,7 +63,7 @@ c     Connectivity table
       if(nb_typ_el2 .gt. nb_typ_el) then
          write(ui,*)
          write(ui,*) "   ???"
-         write(ui,*) "geometry: nb_typ_el2 > nb_typ_el : ", 
+         write(ui,*) "geometry: nb_typ_el2 > nb_typ_el : ",
      *    nb_typ_el2, nb_typ_el
          write(ui,*) "geometry: Aborting..."
          stop
@@ -71,4 +71,3 @@ c     Connectivity table
 
       return
       end
-

--- a/backend/materials.py
+++ b/backend/materials.py
@@ -19,13 +19,15 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import os
 import numpy as np
 from scipy.interpolate import interp1d
 import matplotlib
 matplotlib.use('pdf')
 import matplotlib.pyplot as plt
 
-data_location = '../backend/data/'
+emu_path = os.path.dirname(os.path.abspath(__file__))
+data_location = emu_path + '/data/'
 
 
 class Material(object):

--- a/backend/mode_calcs.py
+++ b/backend/mode_calcs.py
@@ -354,7 +354,7 @@ class Simmo(Modes):
 
         elif self.structure.periodicity == '2D_array':
             # Prepare for the mesh
-            with open("../backend/fortran/msh/"+self.structure.mesh_file) as f:
+            with open(emu_path + "/fortran/msh/"+self.structure.mesh_file) as f:
                 self.n_msh_pts, self.n_msh_el = [int(i) for i in f.readline().split()]
 
             # Size of Fortran's complex superarray (scales with mesh)

--- a/backend/mode_calcs.py
+++ b/backend/mode_calcs.py
@@ -23,7 +23,8 @@ import numpy as np
 import sys
 # from scipy import sqrt
 import os
-sys.path.append("../backend/")
+emu_path = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(emu_path)
 
 from fortran import EMUstack
 

--- a/backend/objects.py
+++ b/backend/objects.py
@@ -26,7 +26,8 @@ import materials
 from mode_calcs import Simmo, Anallo
 from fortran import EMUstack
 
-msh_location = '../backend/fortran/msh/'
+emu_path = os.path.dirname(os.path.abspath(__file__))
+msh_location = emu_path + '/fortran/msh/'
 
 # Acknowledgements
 print '\n##################################################################\n'\

--- a/backend/plotting.py
+++ b/backend/plotting.py
@@ -30,6 +30,7 @@ matplotlib.use('pdf')
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import os
+emu_path = os.path.dirname(os.path.abspath(__file__))
 
 # font = {'family' : 'normal',
 #         'weight' : 'bold',
@@ -283,7 +284,7 @@ def t_r_a_plots(stacks_list, xvalues=None, xlabel='', params_layer=1,
 
     if weight_spec == True:
         # Plot totals weighted by solar irradiance.
-        Irrad_spec_file = '../backend/data/ASTMG173'
+        Irrad_spec_file = emu_path + '/data/ASTMG173'
         i_data = np.loadtxt('%s.txt' % Irrad_spec_file)
         i_spec = np.interp(xvalues, i_data[:,0], i_data[:,3])
         bandgap_wl = xvalues[-1]
@@ -549,7 +550,7 @@ def t_r_a_plots_subs(stacks_list, wavelengths, period, sub_n,
 
     if weight_spec == True:
         # Also plot totals weighted by solar irradiance
-        Irrad_spec_file = '../backend/data/ASTMG173'
+        Irrad_spec_file = emu_path + '/data/ASTMG173'
         i_data       = np.loadtxt('%s.txt' % Irrad_spec_file)
         i_spec       = np.interp(wavelengths, i_data[:,0], i_data[:,3])
         bandgap_wl   = wavelengths[-1]
@@ -887,7 +888,7 @@ def J_short_circuit(active_abs, wavelengths, params_2_print='',
         Assuming every absorbed photon produces a pair of charge carriers.
     """
 
-    Irrad_spec_file = '../backend/data/ASTMG173'
+    Irrad_spec_file = emu_path + '/data/ASTMG173'
     i_data = np.loadtxt('%s.txt' % Irrad_spec_file)
     i_spec = np.interp(wavelengths, i_data[:, 0], i_data[:, 3])
     expression = i_spec*active_abs*wavelengths
@@ -913,7 +914,7 @@ def ult_efficiency(active_abs, wavelengths, bandgap_wl=None,
     """
     if bandgap_wl is None:
         bandgap_wl = np.max(wavelengths)
-    Irrad_spec_file = '../backend/data/ASTMG173'
+    Irrad_spec_file = emu_path + '/data/ASTMG173'
     i_data       = np.loadtxt('%s.txt' % Irrad_spec_file)
     i_spec       = np.interp(wavelengths, i_data[:,0], i_data[:,3])
     expression   = i_spec*active_abs*wavelengths


### PR DESCRIPTION
The aim of this pull request is to remove the hardcoded relative paths from EMUstack python backend. As it is, python scripts using EMUstack can only be run from a folder that is one level up the `EMUstack` installation directory since many hardcoded `../backend/` relative paths are found in the code. In order to run the scripts from any folder I modified the code and run a few test, and hopefully it should be ok. On top of that the `conv_gmsh.f` must be modified in order to accomodate longer filenames and command lines
